### PR TITLE
Detect GPUs automatically and select them by PCI address

### DIFF
--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Quickshell.Io
 import qs.Common
 import qs.Modules.Plugins
 import qs.Services
@@ -7,6 +8,12 @@ import qs.Widgets
 PluginSettings {
     id: root
     pluginId: "amdGpuMonitor"
+
+    // [{ name, pci, suspended }] as reported by amdgpu_top
+    property var detectedGpus: []
+    property string detectError: ""
+    readonly property var gpuLabels: detectedGpus.map(g => g.suspended ? `${g.name} (suspended)` : g.name)
+    property string selectedGpuLabel: ""
 
     function refreshVariants() {
         variantsModel.clear();
@@ -19,6 +26,49 @@ PluginSettings {
 
     Component.onCompleted: {
         refreshVariants();
+        detectGpusProcess.running = true;
+    }
+
+    Process {
+        id: detectGpusProcess
+        command: ["amdgpu_top", "-J", "-n", "1"]
+        running: false
+
+        onExited: exitCode => {
+            if (exitCode !== 0)
+                root.detectError = "Could not run amdgpu_top. Is it installed?";
+        }
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let data;
+                try {
+                    data = JSON.parse(text.trim());
+                } catch (e) {
+                    root.detectError = "Could not parse amdgpu_top output.";
+                    return;
+                }
+
+                const active = (data.devices || []).map(d => ({
+                    name: d["Info"]?.["DeviceName"] || "AMD GPU",
+                    pci: d["Info"]?.["PCI"] || "",
+                    suspended: false
+                }));
+                // Suspended GPUs are listed separately and use flat keys.
+                const asleep = (data.suspended_devices || []).map(d => ({
+                    name: d.DeviceName || "AMD GPU",
+                    pci: d.pci || "",
+                    suspended: true
+                }));
+
+                const all = active.concat(asleep).filter(g => g.pci);
+                all.sort((a, b) => a.pci.localeCompare(b.pci));
+                root.detectedGpus = all;
+                root.detectError = all.length ? "" : "No AMD GPUs detected.";
+                if (all.length && !root.selectedGpuLabel)
+                    root.selectedGpuLabel = root.gpuLabels[0];
+            }
+        }
     }
 
     StyledText {
@@ -95,7 +145,7 @@ PluginSettings {
 
     StyledText {
         width: parent.width
-        text: "Create per-GPU widget variants. Each variant appears as a separate widget in Add Widget and can target a different GPU index."
+        text: "Create per-GPU widget variants. Each variant appears as a separate widget in Add Widget and targets a detected GPU."
         font.pixelSize: Theme.fontSizeSmall
         color: Theme.surfaceVariantText
         wrapMode: Text.WordWrap
@@ -139,38 +189,48 @@ PluginSettings {
                     spacing: Theme.spacingXS
 
                     StyledText {
-                        text: "GPU Index"
+                        text: "GPU"
                         font.pixelSize: Theme.fontSizeSmall
                         color: Theme.surfaceVariantText
                     }
 
-                    DankTextField {
-                        id: variantGpuIndexField
+                    DankDropdown {
                         width: parent.width
-                        placeholderText: "1"
+                        options: root.gpuLabels
+                        currentValue: root.selectedGpuLabel
+                        emptyText: "No GPUs detected"
+                        onValueChanged: value => root.selectedGpuLabel = value
                     }
                 }
+            }
+
+            StyledText {
+                width: parent.width
+                text: root.detectError
+                visible: root.detectError !== ""
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.error
+                wrapMode: Text.WordWrap
             }
 
             DankButton {
                 text: "Create GPU Variant"
                 iconName: "add"
+                enabled: root.detectedGpus.length > 0
                 onClicked: {
-                    const rawIndex = variantGpuIndexField.text.trim();
-                    const parsedIndex = parseInt(rawIndex);
-                    if (rawIndex === "" || isNaN(parsedIndex) || parsedIndex < 0) {
-                        ToastService.showError("Enter a valid GPU index");
+                    const gpu = root.detectedGpus[root.gpuLabels.indexOf(root.selectedGpuLabel)];
+                    if (!gpu) {
+                        ToastService.showError("Select a GPU");
                         return;
                     }
 
-                    const variantName = variantNameField.text.trim() || `GPU ${parsedIndex}`;
+                    const variantName = variantNameField.text.trim() || gpu.name;
                     createVariant(variantName, {
-                        gpuIndex: parsedIndex,
-                        description: `AMD GPU Monitor for GPU ${parsedIndex}`,
+                        gpuPci: gpu.pci,
+                        description: `AMD GPU Monitor for ${gpu.name}`,
                         icon: "memory"
                     });
                     variantNameField.text = "";
-                    variantGpuIndexField.text = "";
                     ToastService.showInfo(`Created variant: ${variantName}`);
                 }
             }
@@ -231,7 +291,7 @@ PluginSettings {
 
                             StyledText {
                                 width: parent.width
-                                text: `GPU ${modelData.gpuIndex ?? 0} • ${modelData.fullId || modelData.id || ""}`
+                                text: `${modelData.gpuPci || `GPU ${modelData.gpuIndex ?? 0}`} • ${modelData.fullId || modelData.id || ""}`
                                 font.pixelSize: Theme.fontSizeSmall - 1
                                 color: Theme.surfaceVariantText
                                 elide: Text.ElideRight

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -30,7 +30,7 @@ PluginSettings {
         const claimed = (variants || []).map(v => v.gpuPci).filter(pci => pci);
         for (const variant of legacy) {
             const gpu = detectedGpus[variant.gpuIndex];
-            if (!gpu || claimed.indexOf(gpu.pci) !== -1)
+            if (!gpu || !gpu.pci || claimed.indexOf(gpu.pci) !== -1)
                 continue;
             claimed.push(gpu.pci);
             adopted.push(gpu.pci);
@@ -285,7 +285,7 @@ PluginSettings {
 
     StyledText {
         width: parent.width
-        text: "Widgets currently saved in your settings. Ones that no longer match a detected GPU can be removed here."
+        text: "Widgets currently saved in your settings. Legacy items can be safely removed here (requires re-adding the widget to your bar)"
         font.pixelSize: Theme.fontSizeSmall
         color: Theme.surfaceVariantText
         wrapMode: Text.WordWrap
@@ -311,7 +311,7 @@ PluginSettings {
 
                     required property var modelData
 
-                    readonly property bool orphaned: !(root.detectedGpus || []).some(g => g.pci === variantEntry.modelData.gpuPci)
+                    readonly property bool legacy: !variantEntry.modelData.gpuPci && variantEntry.modelData.gpuIndex !== undefined
 
                     width: parent.width
                     height: variantRow.implicitHeight + Theme.spacingM * 2
@@ -344,10 +344,10 @@ PluginSettings {
                                 text: {
                                     const variant = variantEntry.modelData;
                                     const target = variant.gpuPci || (variant.gpuIndex !== undefined ? `GPU ${variant.gpuIndex}` : "unassigned");
-                                    return variantEntry.orphaned ? `${target} (not detected)` : target;
+                                    return variantEntry.legacy ? `${target} (legacy)` : target;
                                 }
                                 font.pixelSize: Theme.fontSizeSmall - 1
-                                color: variantEntry.orphaned ? Theme.error : Theme.surfaceVariantText
+                                color: variantEntry.legacy ? Theme.warning : Theme.surfaceVariantText
                                 elide: Text.ElideRight
                             }
                         }

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -18,19 +18,54 @@ PluginSettings {
         return kind ? `Monitor your ${kind.toLowerCase()} ${gpu.name}` : `Monitor your ${gpu.name}`;
     }
 
+    // Pre-PCI variants only carry gpuIndex. Adopt them by position so the sync
+    // below doesn't duplicate them and orphan the originals. Returns the PCI
+    // addresses adopted, whose names came from the user and must not be reset.
+    function migrateLegacyVariants() {
+        const adopted = [];
+        const legacy = (variants || []).filter(v => !v.gpuPci && v.gpuIndex !== undefined);
+        if (legacy.length === 0)
+            return adopted;
+
+        const claimed = (variants || []).map(v => v.gpuPci).filter(pci => pci);
+        for (const variant of legacy) {
+            const gpu = detectedGpus[variant.gpuIndex];
+            if (!gpu || claimed.indexOf(gpu.pci) !== -1)
+                continue;
+            claimed.push(gpu.pci);
+            adopted.push(gpu.pci);
+            updateVariant(variant.id, {
+                gpuPci: gpu.pci,
+                gpuType: gpu.type || "",
+                description: variantDescription(gpu),
+                icon: variant.icon || "memory"
+            });
+        }
+        return adopted;
+    }
+
     // Matched by PCI so a GPU that suspends and returns keeps its existing widget.
     function syncVariantsToGpus() {
+        const adopted = migrateLegacyVariants();
+
         for (const gpu of detectedGpus) {
+            const existing = (variants || []).find(v => v.gpuPci === gpu.pci);
+            // Never clear a remembered type with the empty one a suspended
+            // device reports.
+            const gpuType = gpu.type || existing?.gpuType || "";
+            const name = adopted.indexOf(gpu.pci) !== -1 ? existing.name : gpu.name;
             const config = {
                 gpuPci: gpu.pci,
-                description: variantDescription(gpu),
+                gpuType: gpuType,
+                description: variantDescription({ name: gpu.name, type: gpuType }),
                 icon: "memory"
             };
-            const existing = (variants || []).find(v => v.gpuPci === gpu.pci);
             if (!existing) {
                 createVariant(gpu.name, config);
-            } else if (existing.name !== gpu.name || existing.description !== config.description) {
-                updateVariant(existing.id, Object.assign({ name: gpu.name }, config));
+            } else if (existing.name !== name
+                       || existing.description !== config.description
+                       || existing.gpuType !== gpuType) {
+                updateVariant(existing.id, Object.assign({ name: name }, config));
             }
         }
     }
@@ -67,7 +102,9 @@ PluginSettings {
                     type: d["Info"]?.["GPU Type"] || "",
                     suspended: false
                 }));
-                // Suspended GPUs are listed separately and use flat keys.
+                // Suspended devices serialize from DevicePath, which has no
+                // "GPU Type": reading it needs the device open. Resolved from
+                // the variant in syncVariantsToGpus instead.
                 const asleep = (data.suspended_devices || []).map(d => ({
                     name: d.DeviceName || "AMD GPU",
                     pci: d.pci || "",
@@ -234,6 +271,124 @@ PluginSettings {
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.error
                 wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    StyledText {
+        width: parent.width
+        text: "Configured Widgets"
+        font.pixelSize: Theme.fontSizeMedium
+        font.weight: Font.Medium
+        color: Theme.surfaceText
+    }
+
+    StyledText {
+        width: parent.width
+        text: "Widgets currently saved in your settings. Ones that no longer match a detected GPU can be removed here."
+        font.pixelSize: Theme.fontSizeSmall
+        color: Theme.surfaceVariantText
+        wrapMode: Text.WordWrap
+    }
+
+    Rectangle {
+        width: parent.width
+        height: variantsListColumn.implicitHeight + Theme.spacingM * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: variantsListColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingS
+
+            Repeater {
+                model: root.variants || []
+
+                Rectangle {
+                    id: variantEntry
+
+                    required property var modelData
+
+                    readonly property bool orphaned: !(root.detectedGpus || []).some(g => g.pci === variantEntry.modelData.gpuPci)
+
+                    width: parent.width
+                    height: variantRow.implicitHeight + Theme.spacingM * 2
+                    radius: Theme.cornerRadius
+                    color: Theme.surfaceContainer
+
+                    Row {
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.spacingM
+                        anchors.rightMargin: Theme.spacingS
+                        spacing: Theme.spacingS
+
+                        Column {
+                            id: variantRow
+                            width: parent.width - deleteVariantButton.width - Theme.spacingS
+                            anchors.verticalCenter: parent.verticalCenter
+                            spacing: Theme.spacingXS
+
+                            StyledText {
+                                width: parent.width
+                                text: variantEntry.modelData.name || "Unnamed"
+                                font.pixelSize: Theme.fontSizeSmall
+                                font.weight: Font.Medium
+                                color: Theme.surfaceText
+                                elide: Text.ElideRight
+                            }
+
+                            StyledText {
+                                width: parent.width
+                                text: {
+                                    const variant = variantEntry.modelData;
+                                    const target = variant.gpuPci || (variant.gpuIndex !== undefined ? `GPU ${variant.gpuIndex}` : "unassigned");
+                                    return variantEntry.orphaned ? `${target} (not detected)` : target;
+                                }
+                                font.pixelSize: Theme.fontSizeSmall - 1
+                                color: variantEntry.orphaned ? Theme.error : Theme.surfaceVariantText
+                                elide: Text.ElideRight
+                            }
+                        }
+
+                        Rectangle {
+                            id: deleteVariantButton
+                            width: 28
+                            height: 28
+                            radius: 14
+                            color: deleteVariantArea.containsMouse ? Theme.error : "transparent"
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            DankIcon {
+                                anchors.centerIn: parent
+                                name: "delete"
+                                size: 16
+                                color: deleteVariantArea.containsMouse ? Theme.onError : Theme.surfaceVariantText
+                            }
+
+                            MouseArea {
+                                id: deleteVariantArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    const variant = variantEntry.modelData;
+                                    root.removeVariant(variant.id);
+                                    ToastService.showInfo(`Removed widget: ${variant.name || variant.id}`);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            StyledText {
+                width: parent.width
+                visible: (root.variants || []).length === 0
+                text: "No widgets configured yet."
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceVariantText
             }
         }
     }

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -311,7 +311,7 @@ PluginSettings {
 
                     required property var modelData
 
-                    readonly property bool legacy: !variantEntry.modelData.gpuPci && variantEntry.modelData.gpuIndex !== undefined
+                    readonly property bool legacy: !variantEntry.modelData.gpuPci || variantEntry.modelData.gpuIndex !== undefined
 
                     width: parent.width
                     height: variantRow.implicitHeight + Theme.spacingM * 2

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -9,23 +9,35 @@ PluginSettings {
     id: root
     pluginId: "amdGpuMonitor"
 
-    // [{ name, pci, suspended }] as reported by amdgpu_top
+    // [{ name, pci, type, suspended }] as reported by amdgpu_top
     property var detectedGpus: []
     property string detectError: ""
-    readonly property var gpuLabels: detectedGpus.map(g => g.suspended ? `${g.name} (suspended)` : g.name)
-    property string selectedGpuLabel: ""
 
-    function refreshVariants() {
-        variantsModel.clear();
-        for (let i = 0; i < variants.length; i++) {
-            variantsModel.append(variants[i]);
+    function variantDescription(gpu) {
+        const kind = gpu.type === "APU" ? "Integrated" : gpu.type === "dGPU" ? "Discrete" : "";
+        return kind ? `Monitor your ${kind.toLowerCase()} ${gpu.name}` : `Monitor your ${gpu.name}`;
+    }
+
+    // Matched by PCI so a GPU that suspends and returns keeps its existing widget.
+    function syncVariantsToGpus() {
+        for (const gpu of detectedGpus) {
+            const config = {
+                gpuPci: gpu.pci,
+                description: variantDescription(gpu),
+                icon: "memory"
+            };
+            const existing = (variants || []).find(v => v.gpuPci === gpu.pci);
+            if (!existing) {
+                createVariant(gpu.name, config);
+            } else if (existing.name !== gpu.name || existing.description !== config.description) {
+                updateVariant(existing.id, Object.assign({ name: gpu.name }, config));
+            }
         }
     }
 
-    onVariantsChanged: refreshVariants()
+    onDetectedGpusChanged: syncVariantsToGpus()
 
     Component.onCompleted: {
-        refreshVariants();
         detectGpusProcess.running = true;
     }
 
@@ -52,12 +64,14 @@ PluginSettings {
                 const active = (data.devices || []).map(d => ({
                     name: d["Info"]?.["DeviceName"] || "AMD GPU",
                     pci: d["Info"]?.["PCI"] || "",
+                    type: d["Info"]?.["GPU Type"] || "",
                     suspended: false
                 }));
                 // Suspended GPUs are listed separately and use flat keys.
                 const asleep = (data.suspended_devices || []).map(d => ({
                     name: d.DeviceName || "AMD GPU",
                     pci: d.pci || "",
+                    type: "",
                     suspended: true
                 }));
 
@@ -65,8 +79,6 @@ PluginSettings {
                 all.sort((a, b) => a.pci.localeCompare(b.pci));
                 root.detectedGpus = all;
                 root.detectError = all.length ? "" : "No AMD GPUs detected.";
-                if (all.length && !root.selectedGpuLabel)
-                    root.selectedGpuLabel = root.gpuLabels[0];
             }
         }
     }
@@ -137,7 +149,7 @@ PluginSettings {
 
     StyledText {
         width: parent.width
-        text: "GPU Variants"
+        text: "Your GPUs"
         font.pixelSize: Theme.fontSizeMedium
         font.weight: Font.Medium
         color: Theme.surfaceText
@@ -145,7 +157,7 @@ PluginSettings {
 
     StyledText {
         width: parent.width
-        text: "Create per-GPU widget variants. Each variant appears as a separate widget in Add Widget and targets a detected GPU."
+        text: "Each detected GPU gets its own widget automatically. Add them from Add Widget in the Dank Bar settings."
         font.pixelSize: Theme.fontSizeSmall
         color: Theme.surfaceVariantText
         wrapMode: Text.WordWrap
@@ -153,136 +165,50 @@ PluginSettings {
 
     Rectangle {
         width: parent.width
-        height: variantCreator.implicitHeight + Theme.spacingM * 2
+        height: gpuListColumn.implicitHeight + Theme.spacingM * 2
         radius: Theme.cornerRadius
         color: Theme.surfaceContainerHigh
 
         Column {
-            id: variantCreator
-            anchors.fill: parent
-            anchors.margins: Theme.spacingM
-            spacing: Theme.spacingM
-
-            Row {
-                width: parent.width
-                spacing: Theme.spacingM
-
-                Column {
-                    width: (parent.width - Theme.spacingM) / 2
-                    spacing: Theme.spacingXS
-
-                    StyledText {
-                        text: "Variant Name"
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
-                    }
-
-                    DankTextField {
-                        id: variantNameField
-                        width: parent.width
-                        placeholderText: "GPU 1"
-                    }
-                }
-
-                Column {
-                    width: (parent.width - Theme.spacingM) / 2
-                    spacing: Theme.spacingXS
-
-                    StyledText {
-                        text: "GPU"
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
-                    }
-
-                    DankDropdown {
-                        width: parent.width
-                        options: root.gpuLabels
-                        currentValue: root.selectedGpuLabel
-                        emptyText: "No GPUs detected"
-                        onValueChanged: value => root.selectedGpuLabel = value
-                    }
-                }
-            }
-
-            StyledText {
-                width: parent.width
-                text: root.detectError
-                visible: root.detectError !== ""
-                font.pixelSize: Theme.fontSizeSmall
-                color: Theme.error
-                wrapMode: Text.WordWrap
-            }
-
-            DankButton {
-                text: "Create GPU Variant"
-                iconName: "add"
-                enabled: root.detectedGpus.length > 0
-                onClicked: {
-                    const gpu = root.detectedGpus[root.gpuLabels.indexOf(root.selectedGpuLabel)];
-                    if (!gpu) {
-                        ToastService.showError("Select a GPU");
-                        return;
-                    }
-
-                    const variantName = variantNameField.text.trim() || gpu.name;
-                    createVariant(variantName, {
-                        gpuPci: gpu.pci,
-                        description: `AMD GPU Monitor for ${gpu.name}`,
-                        icon: "memory"
-                    });
-                    variantNameField.text = "";
-                    ToastService.showInfo(`Created variant: ${variantName}`);
-                }
-            }
-        }
-    }
-
-    Rectangle {
-        width: parent.width
-        height: variantsListColumn.implicitHeight + Theme.spacingM * 2
-        radius: Theme.cornerRadius
-        color: Theme.surfaceContainerHigh
-
-        Column {
-            id: variantsListColumn
+            id: gpuListColumn
             anchors.fill: parent
             anchors.margins: Theme.spacingM
             spacing: Theme.spacingS
 
-            StyledText {
-                width: parent.width
-                text: "Existing Variants"
-                font.pixelSize: Theme.fontSizeMedium
-                font.weight: Font.Medium
-                color: Theme.surfaceText
-            }
-
             Repeater {
-                model: variantsModel
+                model: root.detectedGpus
 
                 Rectangle {
                     required property var modelData
 
                     width: parent.width
-                    height: variantRow.implicitHeight + Theme.spacingM * 2
+                    height: gpuRow.implicitHeight + Theme.spacingM * 2
                     radius: Theme.cornerRadius
                     color: Theme.surfaceContainer
 
                     Row {
                         anchors.fill: parent
                         anchors.leftMargin: Theme.spacingM
-                        anchors.rightMargin: Theme.spacingS
-                        spacing: Theme.spacingS
+                        anchors.rightMargin: Theme.spacingM
+                        spacing: Theme.spacingM
+
+                        DankIcon {
+                            id: gpuIcon
+                            name: "memory"
+                            size: 20
+                            color: Theme.surfaceVariantText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
 
                         Column {
-                            id: variantRow
-                            width: parent.width - deleteVariantButton.width - Theme.spacingS
+                            id: gpuRow
+                            width: parent.width - gpuIcon.width - Theme.spacingM * 2
                             anchors.verticalCenter: parent.verticalCenter
                             spacing: Theme.spacingXS
 
                             StyledText {
                                 width: parent.width
-                                text: modelData.name || "Unnamed"
+                                text: modelData.name
                                 font.pixelSize: Theme.fontSizeSmall
                                 font.weight: Font.Medium
                                 color: Theme.surfaceText
@@ -291,37 +217,10 @@ PluginSettings {
 
                             StyledText {
                                 width: parent.width
-                                text: `${modelData.gpuPci || `GPU ${modelData.gpuIndex ?? 0}`} • ${modelData.fullId || modelData.id || ""}`
+                                text: modelData.suspended ? `${modelData.pci} (suspended)` : modelData.pci
                                 font.pixelSize: Theme.fontSizeSmall - 1
                                 color: Theme.surfaceVariantText
                                 elide: Text.ElideRight
-                            }
-                        }
-
-                        Rectangle {
-                            id: deleteVariantButton
-                            width: 28
-                            height: 28
-                            radius: 14
-                            color: deleteVariantArea.containsMouse ? Theme.error : "transparent"
-                            anchors.verticalCenter: parent.verticalCenter
-
-                            DankIcon {
-                                anchors.centerIn: parent
-                                name: "delete"
-                                size: 16
-                                color: deleteVariantArea.containsMouse ? Theme.onError : Theme.surfaceVariantText
-                            }
-
-                            MouseArea {
-                                id: deleteVariantArea
-                                anchors.fill: parent
-                                hoverEnabled: true
-                                cursorShape: Qt.PointingHandCursor
-                                onClicked: {
-                                    removeVariant(modelData.id);
-                                    ToastService.showInfo(`Removed variant: ${modelData.name || modelData.id}`);
-                                }
                             }
                         }
                     }
@@ -330,10 +229,11 @@ PluginSettings {
 
             StyledText {
                 width: parent.width
-                visible: variantsModel.count === 0
-                text: "No GPU variants yet."
+                visible: root.detectError !== ""
+                text: root.detectError
                 font.pixelSize: Theme.fontSizeSmall
-                color: Theme.surfaceVariantText
+                color: Theme.error
+                wrapMode: Text.WordWrap
             }
         }
     }

--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -30,6 +30,11 @@ PluginComponent {
     property real mediaUsage: 0.0
 
     function resetStats() {
+        // A sysfs read in flight would land on top of the cleared state and
+        // show a temperature for a GPU we just reported as idle.
+        if (updateTemperatureFallbackProcess.running)
+            updateTemperatureFallbackProcess.running = false;
+        temperatureFallbackTimeoutTimer.stop();
         gfxUsage = 0.0;
         memUsage = 0.0;
         mediaUsage = 0.0;

--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -23,16 +23,34 @@ PluginComponent {
     property string gpuName: "AMD GPU"
     property var processes: []
     property bool statsError: false
+    property bool gpuSuspended: false
 
     property real gfxUsage: 0.0
     property real memUsage: 0.0
     property real mediaUsage: 0.0
+
+    function resetStats() {
+        gfxUsage = 0.0;
+        memUsage = 0.0;
+        mediaUsage = 0.0;
+        gpuUsage = 0.0;
+        vramUsed = 0.0;
+        vramTotal = 0.0;
+        vramPercent = 0.0;
+        temperature = 0;
+        powerUsage = 0;
+        temperatureSysfsPath = "";
+        processes = [];
+    }
 
     property int updateInterval: Math.max(1000, parseInt(variantData?.updateInterval ?? pluginData.updateInterval ?? "4000") || 4000)
     property string temperatureSysfsPath: ""
 
     property bool minimumWidth: variantData?.minimumWidth ?? pluginData.minimumWidth ?? true
     property int gpuIndex: Math.max(0, parseInt(variantData?.gpuIndex ?? "0") || 0)
+    // amdgpu_top drops runtime-suspended GPUs from `devices`, so positions shift.
+    // Match on PCI address instead; index is only a fallback for older variants.
+    property string gpuPci: (variantData?.gpuPci ?? "").toString()
     property string popoutStyle: variantData?.popoutStyle ?? pluginData.popoutStyle ?? "default"
     property int processListHeight: Math.max(100, Math.min(750, parseInt(variantData?.processListHeight ?? pluginData.processListHeight ?? "250") || 250))
     readonly property string popoutStyleSource: {
@@ -133,21 +151,30 @@ PluginComponent {
 
                 root.statsError = false;
                 const devices = Array.isArray(data.devices) ? data.devices : [];
-                const selectedGpu = devices[root.gpuIndex] || devices[0];
+                const suspended = Array.isArray(data.suspended_devices) ? data.suspended_devices : [];
+
+                let selectedGpu = null;
+                if (root.gpuPci) {
+                    selectedGpu = devices.find(d => d["Info"]?.["PCI"] === root.gpuPci) || null;
+                    if (!selectedGpu) {
+                        // Configured GPU is powered down: report it idle rather than
+                        // silently falling through to whichever card is still awake.
+                        const naps = suspended.find(d => d.pci === root.gpuPci);
+                        if (naps) {
+                            root.resetStats();
+                            root.gpuName = naps.DeviceName || "AMD GPU";
+                            root.gpuSuspended = true;
+                            return;
+                        }
+                    }
+                } else {
+                    selectedGpu = devices[root.gpuIndex] || devices[0];
+                }
+                root.gpuSuspended = false;
 
                 if (!selectedGpu) {
+                    root.resetStats();
                     root.gpuName = "AMD GPU";
-                    root.gfxUsage = 0.0;
-                    root.memUsage = 0.0;
-                    root.mediaUsage = 0.0;
-                    root.gpuUsage = 0.0;
-                    root.vramUsed = 0.0;
-                    root.vramTotal = 0.0;
-                    root.vramPercent = 0.0;
-                    root.temperature = 0;
-                    root.powerUsage = 0;
-                    root.temperatureSysfsPath = "";
-                    root.processes = [];
                     return;
                 }
 
@@ -323,6 +350,7 @@ PluginComponent {
                 name: "shadow"
                 size: root.iconSize
                 color: root.statsError ? Theme.error : Theme.widgetIconColor
+                opacity: root.gpuSuspended ? 0.5 : 1.0
                 anchors.verticalCenter: parent.verticalCenter
             }
 
@@ -376,6 +404,7 @@ PluginComponent {
                 name: "shadow"
                 size: root.iconSize
                 color: root.statsError ? Theme.error : Theme.widgetIconColor
+                opacity: root.gpuSuspended ? 0.5 : 1.0
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 

--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -49,7 +49,7 @@ PluginComponent {
     property bool minimumWidth: variantData?.minimumWidth ?? pluginData.minimumWidth ?? true
     property int gpuIndex: Math.max(0, parseInt(variantData?.gpuIndex ?? "0") || 0)
     // amdgpu_top drops runtime-suspended GPUs from `devices`, so positions shift.
-    // Match on PCI address instead; index is only a fallback for older variants.
+    // gpuIndex is kept only as a fallback for variants created before this.
     property string gpuPci: (variantData?.gpuPci ?? "").toString()
     property string popoutStyle: variantData?.popoutStyle ?? pluginData.popoutStyle ?? "default"
     property int processListHeight: Math.max(100, Math.min(750, parseInt(variantData?.processListHeight ?? pluginData.processListHeight ?? "250") || 250))


### PR DESCRIPTION
Fixes #8, where every variant ended up monitoring the same GPU on laptops with more than one AMD GPU. See the issue for the full breakdown; the short version is that `amdgpu_top` moves a runtime-suspended GPU out of `devices` into `suspended_devices`, so `devices[gpuIndex] || devices[0]` falls back to the wrong card, and the surviving positions shift as GPUs sleep and wake.

## The fix

Select GPUs by PCI address instead of by position. The address is stable and is present in both arrays, as `Info.PCI` for active devices and as the flat `pci` key for suspended ones. When the configured GPU is suspended the widget reports it as idle and dims its icon, instead of silently falling through to whichever card is still awake. `gpuIndex` is still honored as a fallback so existing variants keep working.

Since `amdgpu_top -J` already reports the name and PCI address of every GPU, the plugin now enumerates them and creates one widget per GPU automatically. The settings page lists what was detected, and the manual "variant name + GPU index" form is gone. Variants are matched by PCI address, so a GPU that suspends and comes back keeps its existing widget instead of being duplicated.

Variants created under the old scheme only carry `gpuIndex`, so they are adopted by position on the next settings open and given the matching PCI address, keeping their id and their name. A "Configured Widgets" section lists what is actually saved and allows removing entries, including any that no longer match a detected GPU.

## Result

| Discrete GPU | Integrated GPU | Both in the bar |
|---|---|---|
| <img width="697" height="703" alt="image" src="https://github.com/user-attachments/assets/3041a283-27d1-4f7a-ae23-76e7ae4ce74b" /> | <img width="700" height="818" alt="image" src="https://github.com/user-attachments/assets/050ba648-5f19-4f5e-bf65-ee4e6af03451" /> | <img width="956" height="287" alt="image" src="https://github.com/user-attachments/assets/b5543baf-de6c-4643-a101-c25a3fb9432b" /> <img width="911" height="459" alt="image" src="https://github.com/user-attachments/assets/2b7c901d-b874-4053-ac58-28fe1739b45d" /> |

Tested on a laptop with an RX 6700S (discrete) and a Radeon 680M (integrated),
`amdgpu_top` v0.11.5, with the discrete GPU both suspended and awake.

Closes #8 
