### PR TITLE
Show spinner when loading GPUs in settings

### DIFF
--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -12,6 +12,7 @@ PluginSettings {
     // [{ name, pci, type, suspended }] as reported by amdgpu_top
     property var detectedGpus: []
     property string detectError: ""
+    property bool detecting: true
 
     function variantDescription(gpu) {
         const kind = gpu.type === "APU" ? "Integrated" : gpu.type === "dGPU" ? "Discrete" : "";
@@ -92,6 +93,7 @@ PluginSettings {
         onExited: exitCode => {
             if (exitCode !== 0)
                 root.detectError = "Could not run amdgpu_top. Is it installed?";
+            root.detecting = false;
         }
 
         stdout: StdioCollector {
@@ -101,6 +103,7 @@ PluginSettings {
                     data = JSON.parse(text.trim());
                 } catch (e) {
                     root.detectError = "Could not parse amdgpu_top output.";
+                    root.detecting = false;
                     return;
                 }
 
@@ -124,6 +127,7 @@ PluginSettings {
                 all.sort((a, b) => a.pci.localeCompare(b.pci));
                 root.detectedGpus = all;
                 root.detectError = all.length ? "" : "No AMD GPUs detected.";
+                root.detecting = false;
             }
         }
     }
@@ -210,12 +214,50 @@ PluginSettings {
 
     Rectangle {
         width: parent.width
-        height: gpuListColumn.implicitHeight + Theme.spacingM * 2
+        height: Math.max(resultsColumn.implicitHeight + Theme.spacingM * 2,
+                         root.detecting ? 56 : 0)
         radius: Theme.cornerRadius
         color: Theme.surfaceContainerHigh
 
+        Row {
+            id: detectingRow
+            visible: root.detecting && root.detectedGpus.length === 0
+            anchors.centerIn: parent
+            spacing: Theme.spacingM
+
+            Item {
+                width: 20
+                height: 20
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    id: detectSpinner
+                    name: "progress_activity"
+                    size: 20
+                    color: Theme.surfaceVariantText
+                    anchors.centerIn: parent
+                }
+
+                NumberAnimation on rotation {
+                    from: 0
+                    to: 360
+                    duration: 1000
+                    loops: Animation.Infinite
+                    running: root.detecting && root.detectedGpus.length === 0
+                }
+            }
+
+            StyledText {
+                text: "Detecting GPUs..."
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceVariantText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+
         Column {
-            id: gpuListColumn
+            id: resultsColumn
+            visible: !detectingRow.visible
             anchors.fill: parent
             anchors.margins: Theme.spacingM
             spacing: Theme.spacingS

--- a/README.md
+++ b/README.md
@@ -153,3 +153,8 @@ MIT License — Copyright 2026 Navid A.
 Built for [DankMaterialShell](https://github.com/DankMaterialShell) • Uses [amdgpu_top](https://github.com/Umio-Yasuno/amdgpu_top)
 
 Special thanks to [@skrimix](https://github.com/skrimix) and [@Tz-slayer](https://github.com/Tz-slayer) for contributions and feedback.
+
+<a href="https://github.com/navidagz/dms-amd-gpu-monitor/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=navidagz/dms-amd-gpu-monitor" />
+</a>
+


### PR DESCRIPTION
This pull request improves the user experience during GPU detection in the `AmdGpuMonitorSettings.qml` file by adding a visual loading indicator and better state management. Now, while GPUs are being detected, a spinner and status message are shown, and the results only appear once detection is complete.

**User experience improvements:**

* Added a `detecting` property to track whether GPU detection is in progress, and updated its value appropriately throughout the detection process (`AmdGpuMonitorSettings.qml`). [[1]](diffhunk://#diff-a961cded59900b01e676387c4d6c345604b623ec11f7d5b3f450038219ddb397R15) [[2]](diffhunk://#diff-a961cded59900b01e676387c4d6c345604b623ec11f7d5b3f450038219ddb397R96) [[3]](diffhunk://#diff-a961cded59900b01e676387c4d6c345604b623ec11f7d5b3f450038219ddb397R106) [[4]](diffhunk://#diff-a961cded59900b01e676387c4d6c345604b623ec11f7d5b3f450038219ddb397R130)
* Introduced a loading spinner and "Detecting GPUs..." message that displays while GPUs are being detected, and hides the results list until detection is finished (`AmdGpuMonitorSettings.qml`).

**Documentation:**

* Added a contributors badge to the `README.md` to highlight repository contributors.