### PR TITLE
Poll amdgpu_top once from a shared service instead of per widget

### DIFF
--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -101,9 +101,9 @@ PluginSettings {
         all.sort((a, b) => a.pci.localeCompare(b.pci));
         root.detectedGpus = all;
         root.detecting = false;
-        root.detectError = AmdGpuService.statsError
-            ? "Could not run amdgpu_top. Is it installed?"
-            : all.length ? "" : "No AMD GPUs detected.";
+		root.detectError = AmdGpuService.statsError && !all.length
+		    ? "Could not run amdgpu_top. Is it installed?"
+		    : all.length ? "" : "No AMD GPUs detected.";
     }
 
     // Detection has to work with no widget in the bar, so subscribe while open.

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -29,7 +29,7 @@ PluginSettings {
 
         const claimed = (variants || []).map(v => v.gpuPci).filter(pci => pci);
         for (const variant of legacy) {
-            const gpu = detectedGpus[variant.gpuIndex];
+            const gpu = AmdGpuService.deviceByIndex(variant.gpuIndex);
             if (!gpu || !gpu.pci || claimed.indexOf(gpu.pci) !== -1)
                 continue;
             claimed.push(gpu.pci);
@@ -81,35 +81,19 @@ PluginSettings {
     onDetectedGpusChanged: syncVariantsToGpus()
 
     function refreshDetectedGpus() {
-        const active = AmdGpuService.devices.map(d => ({
-            name: d["Info"]?.["DeviceName"] || "AMD GPU",
-            pci: d["Info"]?.["PCI"] || "",
-            type: d["Info"]?.["GPU Type"] || "",
-            suspended: false
-        }));
-        // Suspended devices serialize from DevicePath, which has no
-        // "GPU Type": reading it needs the device open. Resolved from
-        // the variant in syncVariantsToGpus instead.
-        const asleep = AmdGpuService.suspendedDevices.map(d => ({
-            name: d.DeviceName || "AMD GPU",
-            pci: d.pci || "",
-            type: "",
-            suspended: true
-        }));
-
-        const all = active.concat(asleep).filter(g => g.pci);
+        const all = AmdGpuService.devices.slice();
         all.sort((a, b) => a.pci.localeCompare(b.pci));
         root.detectedGpus = all;
         root.detecting = false;
-		root.detectError = AmdGpuService.statsError && !all.length
-		    ? "Could not run amdgpu_top. Is it installed?"
-		    : all.length ? "" : "No AMD GPUs detected.";
+        root.detectError = AmdGpuService.statsError && !all.length
+            ? "Could not run amdgpu_top. Is it installed?"
+            : all.length ? "" : "No AMD GPUs detected.";
     }
 
     // Detection has to work with no widget in the bar, so subscribe while open.
     Component.onCompleted: {
         AmdGpuService.request(root, 2000);
-        if (AmdGpuService.devices.length || AmdGpuService.suspendedDevices.length)
+        if (AmdGpuService.devices.length)
             refreshDetectedGpus();
     }
     Component.onDestruction: AmdGpuService.release(root)

--- a/AmdGpuMonitorSettings.qml
+++ b/AmdGpuMonitorSettings.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import Quickshell.Io
 import qs.Common
 import qs.Modules.Plugins
 import qs.Services
@@ -81,54 +80,47 @@ PluginSettings {
 
     onDetectedGpusChanged: syncVariantsToGpus()
 
-    Component.onCompleted: {
-        detectGpusProcess.running = true;
+    function refreshDetectedGpus() {
+        const active = AmdGpuService.devices.map(d => ({
+            name: d["Info"]?.["DeviceName"] || "AMD GPU",
+            pci: d["Info"]?.["PCI"] || "",
+            type: d["Info"]?.["GPU Type"] || "",
+            suspended: false
+        }));
+        // Suspended devices serialize from DevicePath, which has no
+        // "GPU Type": reading it needs the device open. Resolved from
+        // the variant in syncVariantsToGpus instead.
+        const asleep = AmdGpuService.suspendedDevices.map(d => ({
+            name: d.DeviceName || "AMD GPU",
+            pci: d.pci || "",
+            type: "",
+            suspended: true
+        }));
+
+        const all = active.concat(asleep).filter(g => g.pci);
+        all.sort((a, b) => a.pci.localeCompare(b.pci));
+        root.detectedGpus = all;
+        root.detecting = false;
+        root.detectError = AmdGpuService.statsError
+            ? "Could not run amdgpu_top. Is it installed?"
+            : all.length ? "" : "No AMD GPUs detected.";
     }
 
-    Process {
-        id: detectGpusProcess
-        command: ["amdgpu_top", "-J", "-n", "1"]
-        running: false
+    // Detection has to work with no widget in the bar, so subscribe while open.
+    Component.onCompleted: {
+        AmdGpuService.request(root, 2000);
+        if (AmdGpuService.devices.length || AmdGpuService.suspendedDevices.length)
+            refreshDetectedGpus();
+    }
+    Component.onDestruction: AmdGpuService.release(root)
 
-        onExited: exitCode => {
-            if (exitCode !== 0)
-                root.detectError = "Could not run amdgpu_top. Is it installed?";
-            root.detecting = false;
+    Connections {
+        target: AmdGpuService
+        function onDevicesChanged() {
+            root.refreshDetectedGpus();
         }
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                let data;
-                try {
-                    data = JSON.parse(text.trim());
-                } catch (e) {
-                    root.detectError = "Could not parse amdgpu_top output.";
-                    root.detecting = false;
-                    return;
-                }
-
-                const active = (data.devices || []).map(d => ({
-                    name: d["Info"]?.["DeviceName"] || "AMD GPU",
-                    pci: d["Info"]?.["PCI"] || "",
-                    type: d["Info"]?.["GPU Type"] || "",
-                    suspended: false
-                }));
-                // Suspended devices serialize from DevicePath, which has no
-                // "GPU Type": reading it needs the device open. Resolved from
-                // the variant in syncVariantsToGpus instead.
-                const asleep = (data.suspended_devices || []).map(d => ({
-                    name: d.DeviceName || "AMD GPU",
-                    pci: d.pci || "",
-                    type: "",
-                    suspended: true
-                }));
-
-                const all = active.concat(asleep).filter(g => g.pci);
-                all.sort((a, b) => a.pci.localeCompare(b.pci));
-                root.detectedGpus = all;
-                root.detectError = all.length ? "" : "No AMD GPUs detected.";
-                root.detecting = false;
-            }
+        function onStatsErrorChanged() {
+            root.refreshDetectedGpus();
         }
     }
 

--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -27,7 +27,7 @@ PluginComponent {
     property int powerUsage: 0
     property string gpuName: "AMD GPU"
     property var processes: []
-    property bool statsError: false
+    readonly property bool statsError: AmdGpuService.statsError
     property bool gpuSuspended: false
 
     property real gfxUsage: 0.0
@@ -80,15 +80,17 @@ PluginComponent {
         id: commonStyles
     }
 
-    Timer {
-        id: updateTimer
-        interval: root.updateInterval
-        running: true
-        repeat: true
-        triggeredOnStart: true
-        onTriggered: {
-            if (!updateGpuStatsProcess.running)
-                updateGpuStatsProcess.running = true;
+    Component.onCompleted: AmdGpuService.request(root, root.updateInterval)
+    Component.onDestruction: AmdGpuService.release(root)
+
+    onUpdateIntervalChanged: AmdGpuService.request(root, root.updateInterval)
+
+    onGpuPciChanged: applyStats()
+
+    Connections {
+        target: AmdGpuService
+        function onDevicesChanged() {
+            root.applyStats();
         }
     }
 
@@ -127,122 +129,83 @@ PluginComponent {
         }
     }
 
-    Process {
-        id: updateGpuStatsProcess
-        command: ["amdgpu_top", "-J", "-n", "1"]
-        running: false
-
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0) {
-                root.statsError = true;
-                console.warn(`amdGpuMonitor: amdgpu_top exited with code ${exitCode}`);
-            }
-        }
-
-        stderr: StdioCollector {
-            onStreamFinished: {
-                const errorText = text.trim();
-                if (errorText.length > 0) {
-                    root.statsError = true;
-                    console.warn(`amdGpuMonitor: ${errorText}`);
-                }
-            }
-        }
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const output = text.trim();
-                let data;
-                try {
-                    data = JSON.parse(output);
-                } catch (e) {
-                    root.statsError = true;
-                    console.warn(`amdGpuMonitor: failed to parse amdgpu_top output: ${e}`);
-                    return;
-                }
-
-                root.statsError = false;
-                const devices = Array.isArray(data.devices) ? data.devices : [];
-                const suspended = Array.isArray(data.suspended_devices) ? data.suspended_devices : [];
-
-                let selectedGpu = null;
-                if (root.gpuPci) {
-                    selectedGpu = devices.find(d => d["Info"]?.["PCI"] === root.gpuPci) || null;
-                    if (!selectedGpu) {
-                        // Configured GPU is powered down: report it idle rather than
-                        // silently falling through to whichever card is still awake.
-                        const naps = suspended.find(d => d.pci === root.gpuPci);
-                        if (naps) {
-                            root.resetStats();
-                            root.gpuName = naps.DeviceName || "AMD GPU";
-                            root.gpuSuspended = true;
-                            return;
-                        }
-                    }
-                } else {
-                    selectedGpu = devices[root.gpuIndex] || devices[0];
-                }
-                root.gpuSuspended = false;
-
-                if (!selectedGpu) {
+    function applyStats() {
+        let selectedGpu = null;
+        if (root.gpuPci) {
+            selectedGpu = AmdGpuService.deviceByPci(root.gpuPci);
+            if (!selectedGpu) {
+                // Configured GPU is powered down: report it idle rather than
+                // silently falling through to whichever card is still awake.
+                const naps = AmdGpuService.suspendedByPci(root.gpuPci);
+                if (naps) {
                     root.resetStats();
-                    root.gpuName = "AMD GPU";
+                    root.gpuName = naps.DeviceName || "AMD GPU";
+                    root.gpuSuspended = true;
                     return;
                 }
-
-                root.gpuName = selectedGpu["Info"]?.["DeviceName"] || `AMD GPU ${root.gpuIndex}`;
-
-                root.gfxUsage = parseFloat(selectedGpu.gpu_activity?.["GFX"]?.value) || 0.0;
-                root.memUsage = parseFloat(selectedGpu.gpu_activity?.["Memory"]?.value) || 0.0;
-                root.mediaUsage = parseFloat(selectedGpu.gpu_activity?.["MediaEngine"]?.value) || 0.0;
-                root.gpuUsage = Math.max(root.gfxUsage, root.memUsage, root.mediaUsage);
-
-                root.vramUsed = parseFloat(selectedGpu["VRAM"]?.["Total VRAM Usage"]?.value) || 0.0;
-                root.vramTotal = parseFloat(selectedGpu["VRAM"]?.["Total VRAM"]?.value) || 0.0;
-                root.vramPercent = root.vramTotal > 0
-                    ? (root.vramUsed / root.vramTotal * 100) : 0.0;
-                const extractedTemperature = root.extractTemperature(selectedGpu);
-                if (extractedTemperature > 0) {
-                    root.temperature = extractedTemperature;
-                    root.temperatureSysfsPath = "";
-                } else if (!root.refreshTemperatureFromSysfs(selectedGpu)) {
-                    root.temperature = 0;
-                }
-                root.powerUsage = parseInt(selectedGpu.Sensors?.["Average Power"]?.value) || 0;
-
-                if (selectedGpu.fdinfo) {
-                    const processList = [];
-
-                    Object.keys(selectedGpu.fdinfo).forEach(pid => {
-                        const procInfo = selectedGpu.fdinfo[pid];
-                        const usage = procInfo.usage?.usage;
-                        if (!usage) return;
-
-                        const vram = usage.VRAM?.value || 0;
-                        const gfx = usage.GFX?.value || 0;
-                        const cpu = usage.CPU?.value || 0;
-
-                        if (vram > 0 || gfx > 0) {
-                            processList.push({
-                                name: procInfo.name || "Unknown",
-                                pid: parseInt(pid),
-                                vram: vram,
-                                vramUnit: usage.VRAM?.unit || "MiB",
-                                gfx: gfx,
-                                cpu: cpu,
-                                gtt: usage.GTT?.value || 0,
-                                compute: usage.Compute?.value || 0
-                            });
-                        }
-                    });
-
-                    processList.sort((a, b) => b.vram - a.vram);
-                    if (!root.processListsEqual(root.processes, processList))
-                        root.processes = processList;
-                } else if (root.processes.length > 0) {
-                    root.processes = [];
-                }
             }
+        } else {
+            selectedGpu = AmdGpuService.deviceByIndex(root.gpuIndex);
+        }
+        root.gpuSuspended = false;
+
+        if (!selectedGpu) {
+            root.resetStats();
+            root.gpuName = "AMD GPU";
+            return;
+        }
+
+        root.gpuName = selectedGpu["Info"]?.["DeviceName"] || `AMD GPU ${root.gpuIndex}`;
+
+        root.gfxUsage = parseFloat(selectedGpu.gpu_activity?.["GFX"]?.value) || 0.0;
+        root.memUsage = parseFloat(selectedGpu.gpu_activity?.["Memory"]?.value) || 0.0;
+        root.mediaUsage = parseFloat(selectedGpu.gpu_activity?.["MediaEngine"]?.value) || 0.0;
+        root.gpuUsage = Math.max(root.gfxUsage, root.memUsage, root.mediaUsage);
+
+        root.vramUsed = parseFloat(selectedGpu["VRAM"]?.["Total VRAM Usage"]?.value) || 0.0;
+        root.vramTotal = parseFloat(selectedGpu["VRAM"]?.["Total VRAM"]?.value) || 0.0;
+        root.vramPercent = root.vramTotal > 0
+            ? (root.vramUsed / root.vramTotal * 100) : 0.0;
+        const extractedTemperature = root.extractTemperature(selectedGpu);
+        if (extractedTemperature > 0) {
+            root.temperature = extractedTemperature;
+            root.temperatureSysfsPath = "";
+        } else if (!root.refreshTemperatureFromSysfs(selectedGpu)) {
+            root.temperature = 0;
+        }
+        root.powerUsage = parseInt(selectedGpu.Sensors?.["Average Power"]?.value) || 0;
+
+        if (selectedGpu.fdinfo) {
+            const processList = [];
+
+            Object.keys(selectedGpu.fdinfo).forEach(pid => {
+                const procInfo = selectedGpu.fdinfo[pid];
+                const usage = procInfo.usage?.usage;
+                if (!usage) return;
+
+                const vram = usage.VRAM?.value || 0;
+                const gfx = usage.GFX?.value || 0;
+                const cpu = usage.CPU?.value || 0;
+
+                if (vram > 0 || gfx > 0) {
+                    processList.push({
+                        name: procInfo.name || "Unknown",
+                        pid: parseInt(pid),
+                        vram: vram,
+                        vramUnit: usage.VRAM?.unit || "MiB",
+                        gfx: gfx,
+                        cpu: cpu,
+                        gtt: usage.GTT?.value || 0,
+                        compute: usage.Compute?.value || 0
+                    });
+                }
+            });
+
+            processList.sort((a, b) => b.vram - a.vram);
+            if (!root.processListsEqual(root.processes, processList))
+                root.processes = processList;
+        } else if (root.processes.length > 0) {
+            root.processes = [];
         }
     }
 

--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -80,7 +80,11 @@ PluginComponent {
         id: commonStyles
     }
 
-    Component.onCompleted: AmdGpuService.request(root, root.updateInterval)
+    Component.onCompleted: {
+        AmdGpuService.request(root, root.updateInterval);
+        if (AmdGpuService.devices.length)
+            applyStats();
+    }
     Component.onDestruction: AmdGpuService.release(root)
 
     onUpdateIntervalChanged: AmdGpuService.request(root, root.updateInterval)
@@ -130,32 +134,29 @@ PluginComponent {
     }
 
     function applyStats() {
-        let selectedGpu = null;
-        if (root.gpuPci) {
-            selectedGpu = AmdGpuService.deviceByPci(root.gpuPci);
-            if (!selectedGpu) {
-                // Configured GPU is powered down: report it idle rather than
-                // silently falling through to whichever card is still awake.
-                const naps = AmdGpuService.suspendedByPci(root.gpuPci);
-                if (naps) {
-                    root.resetStats();
-                    root.gpuName = naps.DeviceName || "AMD GPU";
-                    root.gpuSuspended = true;
-                    return;
-                }
-            }
-        } else {
-            selectedGpu = AmdGpuService.deviceByIndex(root.gpuIndex);
-        }
-        root.gpuSuspended = false;
+        const device = root.gpuPci
+            ? AmdGpuService.deviceByPci(root.gpuPci)
+            : AmdGpuService.deviceByIndex(root.gpuIndex) || AmdGpuService.deviceByIndex(0);
 
-        if (!selectedGpu) {
+        if (!device) {
+            root.gpuSuspended = false;
             root.resetStats();
             root.gpuName = "AMD GPU";
             return;
         }
 
-        root.gpuName = selectedGpu["Info"]?.["DeviceName"] || `AMD GPU ${root.gpuIndex}`;
+        // Powered down: report it idle rather than silently falling through to
+        // whichever card is still awake.
+        if (device.suspended) {
+            root.resetStats();
+            root.gpuName = device.name;
+            root.gpuSuspended = true;
+            return;
+        }
+        root.gpuSuspended = false;
+
+        const selectedGpu = device.stats;
+        root.gpuName = device.name;
 
         root.gfxUsage = parseFloat(selectedGpu.gpu_activity?.["GFX"]?.value) || 0.0;
         root.memUsage = parseFloat(selectedGpu.gpu_activity?.["Memory"]?.value) || 0.0;

--- a/AmdGpuService.qml
+++ b/AmdGpuService.qml
@@ -12,8 +12,9 @@ Singleton {
 
     readonly property int defaultInterval: 4000
 
+    // Every GPU amdgpu_top reported, each carrying name, pci and suspended.
+    // Suspended ones serialize from DevicePath and keep no stats.
     property var devices: []
-    property var suspendedDevices: []
     property bool statsError: false
 
     // Keyed by widget so the copies of a variant mirrored across screens hold a
@@ -43,16 +44,14 @@ Singleton {
     }
 
     function deviceByPci(pci) {
-        return pci ? devices.find(d => d["Info"]?.["PCI"] === pci) || null : null;
+        return pci ? devices.find(d => d.pci === pci) || null : null;
     }
 
-    function suspendedByPci(pci) {
-        return pci ? suspendedDevices.find(d => d.pci === pci) || null : null;
-    }
-
-    // Kept for variants created before GPUs were addressed by PCI.
+    // Kept for variants created before GPUs were addressed by PCI. Positions
+    // came from amdgpu_top's own order and only ever counted awake GPUs, so
+    // both the widget and the settings migration have to resolve them here.
     function deviceByIndex(index) {
-        return devices[index] || devices[0] || null;
+        return devices.filter(d => !d.suspended)[index] || null;
     }
 
     Timer {
@@ -101,8 +100,25 @@ Singleton {
                 }
 
                 root.statsError = false;
-                root.devices = Array.isArray(data.devices) ? data.devices : [];
-                root.suspendedDevices = Array.isArray(data.suspended_devices) ? data.suspended_devices : [];
+
+                const awake = (Array.isArray(data.devices) ? data.devices : []).map(d => ({
+                    name: d["Info"]?.["DeviceName"] || "AMD GPU",
+                    pci: d["Info"]?.["PCI"] || "",
+                    type: d["Info"]?.["GPU Type"] || "",
+                    suspended: false,
+                    stats: d
+                }));
+                const asleep = (Array.isArray(data.suspended_devices) ? data.suspended_devices : []).map(d => ({
+                    name: d.DeviceName || "AMD GPU",
+                    pci: d.pci || "",
+                    // "GPU Type" needs the device open, so a suspended one omits
+                    // it. Consumers fall back to what they already remember.
+                    type: "",
+                    suspended: true,
+                    stats: null
+                }));
+
+                root.devices = awake.concat(asleep).filter(d => d.pci);
             }
         }
     }

--- a/AmdGpuService.qml
+++ b/AmdGpuService.qml
@@ -1,0 +1,109 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// amdgpu_top reports every GPU in a single document, and DankBar builds one bar
+// per screen, so polling here keeps it at one call per tick instead of one per
+// widget per screen.
+Singleton {
+    id: root
+
+    readonly property int defaultInterval: 4000
+
+    property var devices: []
+    property var suspendedDevices: []
+    property bool statsError: false
+
+    // Keyed by widget so the copies of a variant mirrored across screens hold a
+    // slot each, and releasing one never cancels the others.
+    property var subscribers: []
+
+    function request(widget, interval) {
+        const entry = subscribers.find(s => s.widget === widget);
+        if (entry)
+            entry.interval = Math.max(1000, interval || defaultInterval);
+        else
+            subscribers.push({ widget: widget, interval: Math.max(1000, interval || defaultInterval) });
+        sync();
+    }
+
+    function release(widget) {
+        subscribers = subscribers.filter(s => s.widget !== widget);
+        sync();
+    }
+
+    // The fastest widget sets the pace, so a widget at 1s still updates at 1s.
+    function sync() {
+        updateTimer.interval = subscribers.length
+            ? Math.min(...subscribers.map(s => s.interval))
+            : defaultInterval;
+        updateTimer.running = subscribers.length > 0;
+    }
+
+    function deviceByPci(pci) {
+        return pci ? devices.find(d => d["Info"]?.["PCI"] === pci) || null : null;
+    }
+
+    function suspendedByPci(pci) {
+        return pci ? suspendedDevices.find(d => d.pci === pci) || null : null;
+    }
+
+    // Kept for variants created before GPUs were addressed by PCI.
+    function deviceByIndex(index) {
+        return devices[index] || devices[0] || null;
+    }
+
+    Timer {
+        id: updateTimer
+        interval: root.defaultInterval
+        running: false
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: {
+            if (!pollProcess.running)
+                pollProcess.running = true;
+        }
+    }
+
+    Process {
+        id: pollProcess
+        command: ["amdgpu_top", "-J", "-n", "1"]
+        running: false
+
+        onExited: exitCode => {
+            if (exitCode !== 0) {
+                root.statsError = true;
+                console.warn(`amdGpuMonitor: amdgpu_top exited with code ${exitCode}`);
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const errorText = text.trim();
+                if (errorText.length > 0) {
+                    root.statsError = true;
+                    console.warn(`amdGpuMonitor: ${errorText}`);
+                }
+            }
+        }
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let data;
+                try {
+                    data = JSON.parse(text.trim());
+                } catch (e) {
+                    root.statsError = true;
+                    console.warn(`amdGpuMonitor: failed to parse amdgpu_top output: ${e}`);
+                    return;
+                }
+
+                root.statsError = false;
+                root.devices = Array.isArray(data.devices) ? data.devices : [];
+                root.suspendedDevices = Array.isArray(data.suspended_devices) ? data.suspended_devices : [];
+            }
+        }
+    }
+}

--- a/qmldir
+++ b/qmldir
@@ -1,0 +1,1 @@
+singleton AmdGpuService AmdGpuService.qml


### PR DESCRIPTION
Fixes #14, where the process count is variants × screens instead of one. See the issue for the breakdown; the short version is that DankBar builds one bar per screen, so each widget ran its own `Timer` and `Process`, and `amdgpu_top -J -n 1` already returns every GPU in one document, so those calls were asking for the same thing and discarding most of it.

## The fix

Polling moves into `AmdGpuService`, a `pragma Singleton` registered through `qmldir`, holding one `Timer` and one `Process` for the whole plugin. Widgets subscribe on creation and release on destruction, then pick their GPU out of the shared result by PCI address, keeping their own display state and the temperature sysfs fallback. Subscriptions are keyed by widget, so the copies of a variant mirrored across screens hold a slot each and releasing one never cancels the others. The poll interval is the smallest one any live subscriber asks for, so a widget set to 1s still updates at 1s.

The settings page used to spawn its own `amdgpu_top` for GPU detection and now reads the same shared result, subscribing while it is open so detection still works with no widget in the bar.

## Result

Two variants on two screens, 2s interval, sampling `pgrep -c amdgpu_top`:

| | before | after |
|---|---|---|
| processes per tick | 4 | 1 |

Tested on a laptop with an RX 6700S (discrete) and a Radeon 680M (integrated), `amdgpu_top` v0.11.5, on two displays: bar widgets, settings open and closed, and `dms ipc call plugins reload` all hold at one process per tick with no leaked subscription.

Closes #14
