### PR TITLE
fix: scale bar text with barTextSize to match DankBar widgets

### DIFF
--- a/AmdGpuMonitorWidget.qml
+++ b/AmdGpuMonitorWidget.qml
@@ -364,20 +364,20 @@ PluginComponent {
 
                 StyledTextMetrics {
                     id: textBaseline
-                    font.pixelSize: Theme.fontSizeSmall
+                    font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     text: "88% | 8.8GiB"
                 }
 
                 StyledTextMetrics {
                     id: currentTextMetrics
-                    font.pixelSize: Theme.fontSizeSmall
+                    font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     text: `${root.gpuUsage.toFixed(0)}% | ${(root.vramUsed / 1024).toFixed(1)}GiB`
                 }
 
                 StyledText {
                     id: gpuText
                     text: currentTextMetrics.text
-                    font.pixelSize: Theme.fontSizeSmall
+                    font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                     color: Theme.widgetTextColor
                     anchors.fill: parent
                     wrapMode: Text.NoWrap
@@ -404,7 +404,7 @@ PluginComponent {
 
             StyledText {
                 text: `${root.gpuUsage.toFixed(0)}%`
-                font.pixelSize: Theme.fontSizeSmall
+                font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                 color: Theme.widgetTextColor
                 anchors.horizontalCenter: parent.horizontalCenter
             }


### PR DESCRIPTION
## Summary
The bar pill text uses a fixed `Theme.fontSizeSmall`, so it does not follow the bar's `thickness`/`fontScale`/`maximizeWidgetText` settings. Built-in DankBar widgets (Clock, CpuMonitor, etc.) size their text with `Theme.barTextSize()`, which scales with these settings.

This change makes the plugin use the same `Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)` in the horizontal and vertical bar pills.

## Effect
- On a default 48px bar there is no visual difference.
- Only when a user customizes bar thickness or per-bar fontScale does the plugin text now scale consistently with the built-in widgets.